### PR TITLE
Fix bug re: crossref traversals of modules missing toplevel_name

### DIFF
--- a/src_py/docnote_extract/crossrefs.py
+++ b/src_py/docnote_extract/crossrefs.py
@@ -80,10 +80,23 @@ class Crossref:
         ] = ()
 
     def __truediv__(self, traversal: CrossrefTraversal) -> Crossref:
-        return Crossref(
-            module_name=self.module_name,
-            toplevel_name=self.toplevel_name,
-            traversals=(*self.traversals, traversal))
+        # Getattr traversals on a MODULE must result in setting the toplevel
+        # name instead of appending a traversal.
+        if (
+            self.toplevel_name is None
+            and isinstance(traversal, GetattrTraversal)
+        ):
+            return Crossref(
+                module_name=self.module_name,
+                toplevel_name=traversal.name,
+                # Tuples are immutable so we don't need to bother copying it
+                traversals=self.traversals)
+
+        else:
+            return Crossref(
+                module_name=self.module_name,
+                toplevel_name=self.toplevel_name,
+                traversals=(*self.traversals, traversal))
 
 
 class Crossreffed(Protocol):

--- a/tests_py/_summarization.integr8.test.py
+++ b/tests_py/_summarization.integr8.test.py
@@ -52,6 +52,9 @@ class TestSummarization:
 
         money_summary = summary / GetattrTraversal('Money')
         assert isinstance(money_summary, ClassSummary)
+        assert money_summary.crossref is not None
+        assert money_summary.crossref.toplevel_name == 'Money'
+
         money_member_names = {member.name for member in money_summary.members}
         assert 'amount' in money_member_names
         assert 'currency' in money_member_names

--- a/tests_py/crossrefs.test.py
+++ b/tests_py/crossrefs.test.py
@@ -177,3 +177,36 @@ class TestCrossrefMixin:
         assert retval._docnote_extract_metadata.toplevel_name == 'bar'
         assert retval._docnote_extract_metadata.traversals == (
             CallTraversal(args=('foo', 'bar'), kwargs={'baz': 'zab'}),)
+
+
+class TestCrossref:
+
+    def test_traversal_from_module(self):
+        """Truediv-based traversal from a module crossref must result in
+        a module name being set instead of an appended traversal.
+        """
+        before = Crossref(
+            module_name='foo',
+            toplevel_name=None,
+            traversals=())
+
+        result = before / GetattrTraversal('bar')
+
+        assert result is not before
+        assert not result.traversals
+        assert result.toplevel_name == 'bar'
+
+    def test_traversal_from_member(self):
+        """Truediv-based traversal from a module member must result in
+        a traversal being appended to the existing traversals.
+        """
+        before = Crossref(
+            module_name='foo',
+            toplevel_name='bar',
+            traversals=())
+
+        result = before / GetattrTraversal('baz')
+
+        assert result is not before
+        assert result.traversals == (GetattrTraversal('baz'),)
+        assert result.toplevel_name == 'bar'


### PR DESCRIPTION
# Summary

Crossrefs for modules themselves use a ``toplevel_name=None``. However, when constructing new crossrefs of direct module members using the division-based sugar for appending traversals, this results in incorrect crossrefs, since the getattr traversal is applied onto the module itself instead of the toplevel name of the module.

This PR updates the division-based sugar to properly set the ``toplevel_name`` attribute instead of appending a traversal in this case.

# Testing

Added an integration test and unit tests.

# Further notes

There's a case to be made that we'd be better off transitioning everything to just always use traversals, instead of special-casing the direct children of modules. However, this would be a big lift, and it's not clear what else would break. So while this might be something worth entertaining as a future change, it's definitely not in the scope of a quick bugfix.