### PR TITLE
Fix/feat: update typespecs to use normtypes

### DIFF
--- a/sidecars_py/docnote_extract_testpkg/src_py/docnote_extract_testpkg/_hand_rolled/noteworthy.py
+++ b/sidecars_py/docnote_extract_testpkg/src_py/docnote_extract_testpkg/_hand_rolled/noteworthy.py
@@ -23,6 +23,13 @@ DOCNOTE_CONFIG_ATTR: Annotated[
     ] = '_docnote_config'
 
 
+class HasVarsWithAnnotatedUnion:
+    foo: Annotated[
+        float | int,
+        Note('Just here to validate union collapsing')]
+    bar: float | int
+
+
 @docnote(DocnoteConfig(include_in_docs=False))
 def func_with_config():
     """This is here just to make sure that normalization works when a

--- a/src_py/docnote_extract/_extraction.py
+++ b/src_py/docnote_extract/_extraction.py
@@ -933,6 +933,8 @@ def _activatate_tracking_registry(registry: TrackingRegistry):
 
 @dataclass(slots=True, kw_only=True)
 class _ExtractionLoaderState:
+    """
+    """
     fullname: str
     is_firstparty: bool
     stub_strategy: _StubStrategy

--- a/src_py/docnote_extract/_gathering.py
+++ b/src_py/docnote_extract/_gathering.py
@@ -221,6 +221,8 @@ def gather[T: SummaryMetadataProtocol](
 
 @dataclass(slots=True, frozen=True)
 class Docnotes[T: SummaryMetadataProtocol]:
+    """
+    """
     summaries: dict[str, SummaryTreeNode[T]]
 
     def is_firstparty(self, crossref: Crossref) -> bool:

--- a/src_py/docnote_extract/_module_tree.py
+++ b/src_py/docnote_extract/_module_tree.py
@@ -179,6 +179,8 @@ class ConfiguredModuleTreeNode(ModuleTreeNode):
 
 @dataclass(slots=True, frozen=True)
 class SummaryTreeNode[T: SummaryMetadataProtocol](ModuleTreeNode):
+    """
+    """
     _: KW_ONLY
     module_summary: ModuleSummary[T] = field(compare=False, repr=False)
     to_document: Annotated[

--- a/src_py/docnote_extract/_summarization.py
+++ b/src_py/docnote_extract/_summarization.py
@@ -6,6 +6,7 @@ import logging
 from collections.abc import Callable
 from collections.abc import Iterable
 from dataclasses import dataclass
+from dataclasses import field
 from typing import Annotated
 from typing import Any
 from typing import Literal
@@ -102,7 +103,7 @@ class SummaryMetadata(SummaryMetadataProtocol):
     canonical_module: str | None
     to_document: bool
     disowned: bool
-    crossref_namespace: dict[str, Crossref]
+    crossref_namespace: dict[str, Crossref] = field(repr=False)
 
     @classmethod
     def factory(

--- a/src_py/docnote_extract/crossrefs.py
+++ b/src_py/docnote_extract/crossrefs.py
@@ -324,7 +324,7 @@ def make_crossreffed(
 
     # This is separate purely so we can isolate the type: ignore
     retval = CrossrefMetaclass(
-        'Crossref',
+        'Crossreffed',
         (CrossrefMixin,),
         {'_docnote_extract_metadata': new_metadata},
         __docnote_extract_traversal__=True)

--- a/src_py/docnote_extract/crossrefs.py
+++ b/src_py/docnote_extract/crossrefs.py
@@ -13,17 +13,23 @@ from docnote import Note
 
 @dataclass(slots=True, frozen=True)
 class GetattrTraversal:
+    """
+    """
     name: str
 
 
 @dataclass(slots=True, frozen=True)
 class CallTraversal:
+    """
+    """
     args: tuple[Any, ...]
     kwargs: dict[str, Any]
 
 
 @dataclass(slots=True, frozen=True)
 class GetitemTraversal:
+    """
+    """
     key: Any
 
 

--- a/src_py/docnote_extract/normalization.py
+++ b/src_py/docnote_extract/normalization.py
@@ -3,16 +3,35 @@ from __future__ import annotations
 import itertools
 import logging
 from dataclasses import dataclass
+from enum import Enum
 from types import ModuleType
+from types import NoneType
 from types import UnionType
 from typing import Annotated
 from typing import Any
+from typing import ClassVar
+from typing import Final
 from typing import Literal
+from typing import LiteralString
+from typing import Never
+from typing import NoReturn
+from typing import NotRequired
+from typing import Required
+from typing import Self
 from typing import TypeAliasType
+from typing import TypedDict
+from typing import Union
 from typing import cast
-from typing import get_args as get_generic_args
+from typing import get_args as get_type_args
 from typing import get_origin
 from typing import get_type_hints
+
+try:
+    from typing import ReadOnly  # type: ignore
+except ImportError:
+    # This can just be whatever; doesn't matter -- as long as it's guaranteed
+    # to fail an ``is`` comparison!
+    ReadOnly = object()
 
 from docnote import DOCNOTE_CONFIG_ATTR
 from docnote import DocnoteConfig
@@ -49,6 +68,14 @@ def normalize_namespace_item(
         parent_effective_config.get_stackables()
     config_params.update(normalized_annotation.config_params)
 
+    # We have to be careful here, because the __module__ of the singletons
+    # is actually docnote_extract.summaries!
+    canonical_module: str | Literal[Singleton.UNKNOWN] | None
+    if value is Singleton.MISSING:
+        canonical_module = Singleton.UNKNOWN
+    else:
+        canonical_module = getattr(value, '__module__', Singleton.UNKNOWN)
+
     # All done. Filtering comes later; here we JUST want to do the
     # normalization!
     return NormalizedObj(
@@ -57,7 +84,7 @@ def normalize_namespace_item(
         effective_config=DocnoteConfig(**config_params),
         notes=normalized_annotation.notes,
         typespec=normalized_annotation.typespec,
-        canonical_module=getattr(value, '__module__', Singleton.UNKNOWN),
+        canonical_module=canonical_module,
         canonical_name=None)
 
 
@@ -252,14 +279,14 @@ def _get_or_infer_canonical_origin(
         if (
             # Summary:
             # ++  not imported from a tracking module
-            # ++  no ``__module__`` attribute
+            # ++  no ``__name__`` and/or ``__module__`` attribute
             # ++  name contained within ``__all__``
             # Conclusion: assume it's a canonical member.
             name_in_containing_module in containing_dunder_all
             # Summary:
             # ++  not imported from a tracking module (or at least not uniquely
             #     so) -- therefore, either a reftype or an actual value
-            # ++  no ``__module__`` attribute
+            # ++  no ``__name__`` and/or ``__module__`` attribute
             # ++  name contained within **module annotations**
             # Conclusion: assume it's a canonical member. This is almost
             # guaranteed; otherwise you'd have to annotate something you just
@@ -345,83 +372,277 @@ class NormalizedObj:
             + f'({self.canonical_module=}, {self.canonical_name=})')
 
 
+class _TypeSpecSpecialForms(TypedDict, total=False):
+    """This keeps track of any encountered special forms so they can be
+    applied to the root TypeSpec.
+    """
+    has_classvar: bool
+    has_final: bool
+    has_required: bool
+    has_not_required: bool
+    has_read_only: bool
+
+
+def _extract_special_forms(origin: Any) -> _TypeSpecSpecialForms | None:
+    if origin is ClassVar:
+        return {'has_classvar': True}
+    if origin is Final:
+        return {'has_final': True}
+    if origin is Required:
+        return {'has_required': True}
+    if origin is NotRequired:
+        return {'has_not_required': True}
+    if origin is ReadOnly:
+        return {'has_read_only': True}
+
+
 @dataclass(slots=True, frozen=True)
 class TypeSpec:
     """This is used as a container for ``NormalizedType``s. At the
-    moment, it's pretty simple: just a tuple to expand out unions.
-    This remains private, though, because if and when python introduces
-    an intersection type, this will get a whole lot more complicated.
+    moment, it's pretty simple: a tree that contains a single normalized
+    type or normalized union type. If and when python adds intersection
+    types, it will be expanded to include those.
+
+    **These are not meant to be constructed directly.** Instead, use the
+    ``from_typehint`` method to create them.
     """
-    _types: tuple[NormalizedType, ...]
+    normtype: NormalizedType
+    has_classvar: bool = False
+    has_final: bool = False
+    has_required: bool = False
+    has_not_required: bool = False
+    has_read_only: bool = False
 
-    def __format__(self, fmtinfo: str) -> str:
-        """If you don't want to actually resolve the annotation, and you
-        just want to stringify it, then use normal string formatting.
-        """
-        raise NotImplementedError
-
+    # The noqa flags are due to normalization hell; they're all about this
+    # being too complicated of a method
     @classmethod
-    def from_typehint(
+    def from_typehint(  # noqa: C901, PLR0912
             cls,
-            typehint: Crossreffed | type | TypeAliasType | UnionType | list
+            typehint:
+                Crossreffed | type | TypeAliasType | UnionType | list | None,
+            *,
+            _special_forms: _TypeSpecSpecialForms | None = None
             ) -> TypeSpec:
         """Converts an extracted type hint into a NormalizedType
         instance.
-
-        TODO: this needs a way to (either optionally or automatically)
-        expand private type aliases.
         """
+        if _special_forms is None:
+            special_forms = _TypeSpecSpecialForms()
+        else:
+            special_forms = _special_forms
+
+        normtype: NormalizedType
         if is_crossreffed(typehint):
-            return cls((NormalizedType(typehint._docnote_extract_metadata),))
+            normtype = NormalizedConcreteType(
+                typehint._docnote_extract_metadata)
+
+        elif NormalizedSpecialType.is_special_type(typehint):
+            normtype = NormalizedSpecialType.from_typehint(typehint)
 
         elif isinstance(typehint, UnionType):
-            norm_types = set()
-            for union_member in typehint.__args__:
-                norm_types.update(cls.from_typehint(union_member)._types)
-            return cls(tuple(norm_types))
+            normtype = NormalizedUnionType.from_typehint(
+                get_type_args(typehint))
 
         elif isinstance(typehint, TypeAliasType):
-            return cls((NormalizedType(Crossref(
-                module_name=typehint.__module__,
-                toplevel_name=typehint.__name__)),))
+            # Note that any type params here aren't relevant; they won't be
+            # bound vars! They'll just be as-declared on the alias, which will
+            # be documented (if needed) on the alias itself.
+            normtype = NormalizedConcreteType(Crossref.from_object(typehint))
 
         # This is the case in some special forms, like the argspec for
         # callables
         elif isinstance(typehint, list):
-            return cls((NormalizedType(
-                primary=None,
+            normtype = NormalizedEmptyGenericType(
                 params=tuple(
-                    TypeSpec.from_typehint(generic_arg)
-                    for generic_arg in typehint)),))
+                    cls.from_typehint(generic_arg)
+                    for generic_arg in typehint))
 
         else:
+            # Note that this will return ``None`` for generics that have not
+            # been passed a parameter. This is usually not a recoverable
+            # situation; the only exception is type vars, which have the
+            # ``__type_params__`` attribute, but that is only available for
+            # type aliases, which we already handled.
             origin = get_origin(typehint)
-            # Non-generics
+            # ----------------  Non-generics
             if origin is None:
                 # This is necessary because we're using TypeGuard instead of
                 # TypeIs so that we can have pseudo-intersections.
                 typehint = cast(type, typehint)
-                return cls((NormalizedType(Crossref(
-                    module_name=typehint.__module__,
-                    toplevel_name=typehint.__name__)),))
 
-            # Generics
+                normtype = NormalizedConcreteType(
+                    Crossref.from_object(typehint))
+
+            # ---------------- Special-case generics
+            elif origin is Literal:
+                normtype = NormalizedLiteralType.from_typehint(typehint)
+
+            # THIS MIGHT STILL BE A UNION TYPE!
+            # Things typed as ``Optional[...]`` will be converted behind
+            # the scenes into a ``_UnionGenericAlias`` type, which is,
+            # well, a generic -- **but the origin will be a plain union!**
+            elif origin is Union:
+                normtype = NormalizedUnionType.from_typehint(
+                        get_type_args(typehint))
+
+            # Theoretically possible because Annotated doesn't always get
+            # collapsed when nested in weird ways.
+            elif origin is Annotated:
+                # Pyright thinks this is a crossref; no idea why
+                typehint = cast(type, typehint)
+                # Here we want to fully unpack things and just defer to it,
+                # bypassing our usual special forms assignments
+                return cls.from_typehint(
+                    typehint.__origin__,
+                    _special_forms=special_forms)
+
+            # We want to normalize the special forms into the root TypeSpec
+            # for convenience; otherwise they make processing things difficult
+            # downstream, since you're constantly checking for them
+            elif (
+                update_special_forms := _extract_special_forms(origin)
+            ) is not None:
+                type_args = get_type_args(typehint)
+                if len(type_args) != 1:
+                    raise TypeError(
+                        'Unsupported arg count for special-form type!',
+                        typehint)
+
+                special_forms.update(update_special_forms)
+                return cls.from_typehint(
+                    type_args[0], _special_forms=special_forms)
+
+            # ----------------  (ahem...) Generic generics
             else:
-                return cls((NormalizedType(
-                    primary=origin,
+                normtype = NormalizedConcreteType(
+                    primary=Crossref.from_object(origin),
                     params=tuple(
-                        TypeSpec.from_typehint(generic_arg)
-                        for generic_arg in get_generic_args(typehint))),))
+                        cls.from_typehint(generic_arg)
+                        for generic_arg in get_type_args(typehint)))
+
+        return cls(normtype, **special_forms)
 
 
 @dataclass(slots=True, frozen=True)
-class NormalizedType:
+class NormalizedUnionType:
+    """This is used as a container for the members of union types. In
+    the future, if python adds an intersection type, it will need to be
+    included here as well.
+    """
+    normtypes: frozenset[NormalizedType]
+
+    @classmethod
+    def from_typehint(
+            cls,
+            typehint: tuple[
+                Crossreffed | type | TypeAliasType | UnionType | list, ...]
+            ) -> NormalizedUnionType:
+        norm_types = set()
+
+        for union_member in typehint:
+            # Note that we don't want to bubble out any special forms from
+            # the parent into the members of the union; that's not the way
+            # that typing works. In theory, the type checker will fail this,
+            # since it wouldn't be a valid declaration, but we want to be
+            # resilient against that (because it's trivial to do so; we just
+            # don't pass in the _special_forms argument!)
+            norm_types.add(TypeSpec.from_typehint(union_member).normtype)
+
+        return cls(frozenset(norm_types))
+
+
+class NormalizedSpecialType(Enum):
+    """There are several special types in python; we use this to mark
+    them in a way that doesn't require a crossref.
+    """
+    ANY = Any
+    # Deliberately omitting AnyStr since it's deprecated
+    LITERAL_STRING = LiteralString
+    NEVER = Never
+    NORETURN = NoReturn
+    SELF = Self
+    NONE = NoneType
+
+    @classmethod
+    def from_typehint(
+            cls,
+            typehint: Any,
+            ) -> NormalizedSpecialType:
+        if typehint is None:
+            typehint = NoneType
+
+        return cls(typehint)
+
+    @classmethod
+    def is_special_type(cls, typehint: Any) -> bool:
+        """Returns if the passed typehint is in fact a special type.
+        """
+        # Note: we want to be both fast AND resilient against unhashable types,
+        # so no sets here!
+        return (
+            typehint is Any
+            or typehint is LiteralString
+            or typehint is Never
+            or typehint is NoReturn
+            or typehint is Self
+            or typehint is NoneType
+            or typehint is None)
+
+
+@dataclass(slots=True, frozen=True)
+class NormalizedConcreteType:
     """This is used for all type annotations after normalization.
     """
     # None is used for some special forms (for example, the argspec for
     # callables)
-    primary: Crossref | None
+    primary: Crossref
     params: tuple[TypeSpec, ...] = ()
+
+
+@dataclass(slots=True, frozen=True)
+class NormalizedEmptyGenericType:
+    """This is used for some special-form type annotations that are
+    effectively just an empty generic -- for example, the argspec in a
+    callable.
+    """
+    params: tuple[TypeSpec, ...] = ()
+
+
+@dataclass(slots=True, frozen=True)
+class NormalizedLiteralType:
+    values: frozenset[int | bool | str | bytes | Crossref]
+
+    @classmethod
+    def from_typehint(
+            cls,
+            typehint: Any
+            ) -> NormalizedLiteralType:
+        values: set[int | bool | str | bytes | Crossref] = set()
+
+        for type_arg in get_type_args(typehint):
+            if isinstance(type_arg, int | bool | str | bytes | Crossref):
+                values.add(type_arg)
+
+            elif is_crossreffed(type_arg):
+                values.add(type_arg._docnote_extract_metadata)
+
+            # Note: this must be a enum object! (and a live one, not a
+            # crossref -- hence needing to convert it)
+            elif isinstance(type_arg, Enum):
+                values.add(Crossref.from_object(type_arg))
+
+            else:
+                raise TypeError('Invalid type for literal arg!', typehint)
+
+        return cls(frozenset(values))
+
+
+type NormalizedType = (
+    NormalizedUnionType
+    | NormalizedEmptyGenericType
+    | NormalizedConcreteType
+    | NormalizedSpecialType
+    | NormalizedLiteralType)
 
 
 @dataclass(slots=True, frozen=True)
@@ -430,12 +651,6 @@ class LazyResolvingValue:
     """
     _crossref: Crossref | None
     _value: Literal[Singleton.MISSING] | Any
-
-    def __format__(self, fmtinfo: str) -> str:
-        """If you don't want to actually resolve the annotation, and you
-        just want to stringify it, then use normal string formatting.
-        """
-        raise NotImplementedError
 
     def __call__(self) -> Any:
         """Resolves the actual annotation. Note that the import hook

--- a/src_py/docnote_extract/normalization.py
+++ b/src_py/docnote_extract/normalization.py
@@ -63,6 +63,8 @@ def normalize_namespace_item(
 
 @dataclass(slots=True)
 class NormalizedAnnotation:
+    """
+    """
     typespec: TypeSpec | None
     notes: tuple[Note, ...]
     config_params: DocnoteConfigParams
@@ -424,6 +426,8 @@ class NormalizedType:
 
 @dataclass(slots=True, frozen=True)
 class LazyResolvingValue:
+    """
+    """
     _crossref: Crossref | None
     _value: Literal[Singleton.MISSING] | Any
 

--- a/src_py/docnote_extract/summaries.py
+++ b/src_py/docnote_extract/summaries.py
@@ -34,6 +34,8 @@ class Singleton(Enum):
 
 @dataclass(slots=True)
 class ObjClassification:
+    """
+    """
     is_reftype: bool
     has_traversals: bool | None
     is_module: bool
@@ -189,6 +191,8 @@ class ParamStyle(Enum):
 
 @dataclass(slots=True, frozen=True, kw_only=True)
 class DocText:
+    """
+    """
     value: str
     markup_lang: str | MarkupLang | None
 
@@ -329,6 +333,8 @@ type NamespaceMemberSummary[T: SummaryMetadataProtocol] = (
 
 @dataclass(slots=True, frozen=True, kw_only=True)
 class SummaryBase[T: SummaryMetadataProtocol](_SummaryBaseProtocol[T]):
+    """
+    """
     crossref: Crossref | None
     ordering_index: int | None
     child_groups: Annotated[
@@ -347,6 +353,8 @@ class SummaryBase[T: SummaryMetadataProtocol](_SummaryBaseProtocol[T]):
 
 @dataclass(slots=True, frozen=True, kw_only=True)
 class ModuleSummary[T: SummaryMetadataProtocol](SummaryBase[T]):
+    """
+    """
     name: Annotated[str, Note('The module fullname, ex ``foo.bar.baz``.')]
     dunder_all: frozenset[str] | None
     docstring: DocText | None
@@ -410,8 +418,6 @@ class VariableSummary[T: SummaryMetadataProtocol](SummaryBase[T]):
     class members. Note that within a class, variables annotated as
     ``ClassVar``s will have the literal ``ClassVar`` added to their
     ``annotations`` tuple.
-
-    TODO: classvar, Final, etc
     """
     name: str
     typespec: Annotated[

--- a/tests_py/_gathering.e2e.test.py
+++ b/tests_py/_gathering.e2e.test.py
@@ -6,6 +6,12 @@ from docnote_extract import SummaryMetadata
 from docnote_extract import gather
 from docnote_extract._module_tree import SummaryTreeNode
 from docnote_extract.crossrefs import Crossref
+from docnote_extract.crossrefs import GetattrTraversal
+from docnote_extract.normalization import NormalizedConcreteType
+from docnote_extract.normalization import NormalizedLiteralType
+from docnote_extract.normalization import NormalizedUnionType
+from docnote_extract.summaries import ClassSummary
+from docnote_extract.summaries import VariableSummary
 
 
 @pytest.fixture(scope='module')
@@ -47,3 +53,46 @@ class TestGatheringE2E:
             for child in money_mod_summary.members
             if child.metadata.included}
         assert resulting_names == {'amount_getter', 'Money'}
+
+    def test_spotcheck_currency(self, testpkg_docs: Docnotes[SummaryMetadata]):
+        """A spot-check of the finnr currency module must match the
+        expected results. This is particularly concerned with the
+        typespec values.
+        """
+        (_, tree_root), = testpkg_docs.summaries.items()
+        currency_mod_node = tree_root.find(
+            'docnote_extract_testpkg.taevcode.finnr.currency')
+        currency_mod_summary = currency_mod_node.module_summary
+        currency_summary = currency_mod_summary / GetattrTraversal('Currency')
+        assert isinstance(currency_summary, ClassSummary)
+
+        name_summary = currency_summary / GetattrTraversal('name')
+        assert isinstance(name_summary, VariableSummary)
+
+        assert name_summary.typespec is not None
+        assert isinstance(
+            name_summary.typespec.normtype,
+            NormalizedUnionType)
+        assert len(name_summary.typespec.normtype.normtypes) == 2
+
+        normtype1, normtype2 = name_summary.typespec.normtype.normtypes
+
+        if isinstance(normtype1, NormalizedConcreteType):
+            concrete_union_member = normtype1
+            literal_union_member = normtype2
+        else:
+            concrete_union_member = normtype2
+            literal_union_member = normtype1
+
+        # Note that this also catches the else statement in case the types
+        # were completely off
+        assert isinstance(concrete_union_member, NormalizedConcreteType)
+        assert isinstance(literal_union_member, NormalizedLiteralType)
+
+        assert concrete_union_member.primary.toplevel_name == 'str'
+        assert not concrete_union_member.primary.traversals
+        assert len(literal_union_member.values) == 1
+        literal_value, = literal_union_member.values
+        assert isinstance(literal_value, Crossref)
+        assert literal_value.toplevel_name == 'Singleton'
+        assert literal_value.traversals == (GetattrTraversal('UNKNOWN'),)

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 3
 requires-python = ">=3.12"
 
 [manifest]
@@ -18,36 +19,36 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/b4/636b3b65173d3ce9a38ef5f0522789614e590dab6a8d505340a4efe4c567/anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6", size = 213252 }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/b4/636b3b65173d3ce9a38ef5f0522789614e590dab6a8d505340a4efe4c567/anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6", size = 213252, upload-time = "2025-08-04T08:54:26.451Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/12/e5e0282d673bb9746bacfb6e2dba8719989d3660cdb2ea79aee9a9651afb/anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1", size = 107213 },
+    { url = "https://files.pythonhosted.org/packages/6f/12/e5e0282d673bb9746bacfb6e2dba8719989d3660cdb2ea79aee9a9651afb/anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1", size = 107213, upload-time = "2025-08-04T08:54:24.882Z" },
 ]
 
 [[package]]
 name = "certifi"
 version = "2025.8.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dc/67/960ebe6bf230a96cda2e0abcf73af550ec4f090005363542f0765df162e0/certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407", size = 162386 }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/67/960ebe6bf230a96cda2e0abcf73af550ec4f090005363542f0765df162e0/certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407", size = 162386, upload-time = "2025-08-03T03:07:47.08Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/48/1549795ba7742c948d2ad169c1c8cdbae65bc450d6cd753d124b17c8cd32/certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5", size = 161216 },
+    { url = "https://files.pythonhosted.org/packages/e5/48/1549795ba7742c948d2ad169c1c8cdbae65bc450d6cd753d124b17c8cd32/certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5", size = 161216, upload-time = "2025-08-03T03:07:45.777Z" },
 ]
 
 [[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
 ]
 
 [[package]]
 name = "docnote"
 version = "2025.8.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/2d/370b534d6c052527646413e56f1aed8d6ef3a0cc15ffe842850c623185bb/docnote-2025.8.5.0.tar.gz", hash = "sha256:3a9fd348a56ad8345db6eba939b88d7eecd853c43b677db6c01bc5fe9f8aa32d", size = 5582 }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/2d/370b534d6c052527646413e56f1aed8d6ef3a0cc15ffe842850c623185bb/docnote-2025.8.5.0.tar.gz", hash = "sha256:3a9fd348a56ad8345db6eba939b88d7eecd853c43b677db6c01bc5fe9f8aa32d", size = 5582, upload-time = "2025-08-05T11:52:34.418Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/19/ca8ddc580c02d782549df6b2c214f44a517fc174db671fbb0b38a3a6008f/docnote-2025.8.5.0-py3-none-any.whl", hash = "sha256:301691e49d868b56f85db4b6bc9b8c28765ea4bd8ff4e55eaef05479c87a633e", size = 5844 },
+    { url = "https://files.pythonhosted.org/packages/58/19/ca8ddc580c02d782549df6b2c214f44a517fc174db671fbb0b38a3a6008f/docnote-2025.8.5.0-py3-none-any.whl", hash = "sha256:301691e49d868b56f85db4b6bc9b8c28765ea4bd8ff4e55eaef05479c87a633e", size = 5844, upload-time = "2025-08-05T11:52:33.262Z" },
 ]
 
 [[package]]
@@ -104,9 +105,9 @@ source = { editable = "sidecars_py/docnote_extract_testutils" }
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250 }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515 },
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
 ]
 
 [[package]]
@@ -117,9 +118,9 @@ dependencies = [
     { name = "certifi" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484 }
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784 },
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
 ]
 
 [[package]]
@@ -132,59 +133,59 @@ dependencies = [
     { name = "httpcore" },
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
 ]
 
 [[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
 ]
 
 [[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727 }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469 },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631 }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217 },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]
 name = "pytest"
-version = "8.4.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -193,59 +194,60 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714 }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474 },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]
 name = "ruff"
-version = "0.12.7"
+version = "0.12.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/81/0bd3594fa0f690466e41bd033bdcdf86cba8288345ac77ad4afbe5ec743a/ruff-0.12.7.tar.gz", hash = "sha256:1fc3193f238bc2d7968772c82831a4ff69252f673be371fb49663f0068b7ec71", size = 5197814 }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/f0/e0965dd709b8cabe6356811c0ee8c096806bb57d20b5019eb4e48a117410/ruff-0.12.12.tar.gz", hash = "sha256:b86cd3415dbe31b3b46a71c598f4c4b2f550346d1ccf6326b347cc0c8fd063d6", size = 5359915, upload-time = "2025-09-04T16:50:18.273Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/d2/6cb35e9c85e7a91e8d22ab32ae07ac39cc34a71f1009a6f9e4a2a019e602/ruff-0.12.7-py3-none-linux_armv6l.whl", hash = "sha256:76e4f31529899b8c434c3c1dede98c4483b89590e15fb49f2d46183801565303", size = 11852189 },
-    { url = "https://files.pythonhosted.org/packages/63/5b/a4136b9921aa84638f1a6be7fb086f8cad0fde538ba76bda3682f2599a2f/ruff-0.12.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:789b7a03e72507c54fb3ba6209e4bb36517b90f1a3569ea17084e3fd295500fb", size = 12519389 },
-    { url = "https://files.pythonhosted.org/packages/a8/c9/3e24a8472484269b6b1821794141f879c54645a111ded4b6f58f9ab0705f/ruff-0.12.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2e1c2a3b8626339bb6369116e7030a4cf194ea48f49b64bb505732a7fce4f4e3", size = 11743384 },
-    { url = "https://files.pythonhosted.org/packages/26/7c/458dd25deeb3452c43eaee853c0b17a1e84169f8021a26d500ead77964fd/ruff-0.12.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32dec41817623d388e645612ec70d5757a6d9c035f3744a52c7b195a57e03860", size = 11943759 },
-    { url = "https://files.pythonhosted.org/packages/7f/8b/658798472ef260ca050e400ab96ef7e85c366c39cf3dfbef4d0a46a528b6/ruff-0.12.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47ef751f722053a5df5fa48d412dbb54d41ab9b17875c6840a58ec63ff0c247c", size = 11654028 },
-    { url = "https://files.pythonhosted.org/packages/a8/86/9c2336f13b2a3326d06d39178fd3448dcc7025f82514d1b15816fe42bfe8/ruff-0.12.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a828a5fc25a3efd3e1ff7b241fd392686c9386f20e5ac90aa9234a5faa12c423", size = 13225209 },
-    { url = "https://files.pythonhosted.org/packages/76/69/df73f65f53d6c463b19b6b312fd2391dc36425d926ec237a7ed028a90fc1/ruff-0.12.7-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:5726f59b171111fa6a69d82aef48f00b56598b03a22f0f4170664ff4d8298efb", size = 14182353 },
-    { url = "https://files.pythonhosted.org/packages/58/1e/de6cda406d99fea84b66811c189b5ea139814b98125b052424b55d28a41c/ruff-0.12.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:74e6f5c04c4dd4aba223f4fe6e7104f79e0eebf7d307e4f9b18c18362124bccd", size = 13631555 },
-    { url = "https://files.pythonhosted.org/packages/6f/ae/625d46d5164a6cc9261945a5e89df24457dc8262539ace3ac36c40f0b51e/ruff-0.12.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5d0bfe4e77fba61bf2ccadf8cf005d6133e3ce08793bbe870dd1c734f2699a3e", size = 12667556 },
-    { url = "https://files.pythonhosted.org/packages/55/bf/9cb1ea5e3066779e42ade8d0cd3d3b0582a5720a814ae1586f85014656b6/ruff-0.12.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06bfb01e1623bf7f59ea749a841da56f8f653d641bfd046edee32ede7ff6c606", size = 12939784 },
-    { url = "https://files.pythonhosted.org/packages/55/7f/7ead2663be5627c04be83754c4f3096603bf5e99ed856c7cd29618c691bd/ruff-0.12.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e41df94a957d50083fd09b916d6e89e497246698c3f3d5c681c8b3e7b9bb4ac8", size = 11771356 },
-    { url = "https://files.pythonhosted.org/packages/17/40/a95352ea16edf78cd3a938085dccc55df692a4d8ba1b3af7accbe2c806b0/ruff-0.12.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:4000623300563c709458d0ce170c3d0d788c23a058912f28bbadc6f905d67afa", size = 11612124 },
-    { url = "https://files.pythonhosted.org/packages/4d/74/633b04871c669e23b8917877e812376827c06df866e1677f15abfadc95cb/ruff-0.12.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:69ffe0e5f9b2cf2b8e289a3f8945b402a1b19eff24ec389f45f23c42a3dd6fb5", size = 12479945 },
-    { url = "https://files.pythonhosted.org/packages/be/34/c3ef2d7799c9778b835a76189c6f53c179d3bdebc8c65288c29032e03613/ruff-0.12.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a07a5c8ffa2611a52732bdc67bf88e243abd84fe2d7f6daef3826b59abbfeda4", size = 12998677 },
-    { url = "https://files.pythonhosted.org/packages/77/ab/aca2e756ad7b09b3d662a41773f3edcbd262872a4fc81f920dc1ffa44541/ruff-0.12.7-py3-none-win32.whl", hash = "sha256:c928f1b2ec59fb77dfdf70e0419408898b63998789cc98197e15f560b9e77f77", size = 11756687 },
-    { url = "https://files.pythonhosted.org/packages/b4/71/26d45a5042bc71db22ddd8252ca9d01e9ca454f230e2996bb04f16d72799/ruff-0.12.7-py3-none-win_amd64.whl", hash = "sha256:9c18f3d707ee9edf89da76131956aba1270c6348bfee8f6c647de841eac7194f", size = 12912365 },
-    { url = "https://files.pythonhosted.org/packages/4c/9b/0b8aa09817b63e78d94b4977f18b1fcaead3165a5ee49251c5d5c245bb2d/ruff-0.12.7-py3-none-win_arm64.whl", hash = "sha256:dfce05101dbd11833a0776716d5d1578641b7fddb537fe7fa956ab85d1769b69", size = 11982083 },
+    { url = "https://files.pythonhosted.org/packages/09/79/8d3d687224d88367b51c7974cec1040c4b015772bfbeffac95face14c04a/ruff-0.12.12-py3-none-linux_armv6l.whl", hash = "sha256:de1c4b916d98ab289818e55ce481e2cacfaad7710b01d1f990c497edf217dafc", size = 12116602, upload-time = "2025-09-04T16:49:18.892Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c3/6e599657fe192462f94861a09aae935b869aea8a1da07f47d6eae471397c/ruff-0.12.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7acd6045e87fac75a0b0cdedacf9ab3e1ad9d929d149785903cff9bb69ad9727", size = 12868393, upload-time = "2025-09-04T16:49:23.043Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d2/9e3e40d399abc95336b1843f52fc0daaceb672d0e3c9290a28ff1a96f79d/ruff-0.12.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:abf4073688d7d6da16611f2f126be86523a8ec4343d15d276c614bda8ec44edb", size = 12036967, upload-time = "2025-09-04T16:49:26.04Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/03/6816b2ed08836be272e87107d905f0908be5b4a40c14bfc91043e76631b8/ruff-0.12.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:968e77094b1d7a576992ac078557d1439df678a34c6fe02fd979f973af167577", size = 12276038, upload-time = "2025-09-04T16:49:29.056Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d5/707b92a61310edf358a389477eabd8af68f375c0ef858194be97ca5b6069/ruff-0.12.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42a67d16e5b1ffc6d21c5f67851e0e769517fb57a8ebad1d0781b30888aa704e", size = 11901110, upload-time = "2025-09-04T16:49:32.07Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/3d/f8b1038f4b9822e26ec3d5b49cf2bc313e3c1564cceb4c1a42820bf74853/ruff-0.12.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b216ec0a0674e4b1214dcc998a5088e54eaf39417327b19ffefba1c4a1e4971e", size = 13668352, upload-time = "2025-09-04T16:49:35.148Z" },
+    { url = "https://files.pythonhosted.org/packages/98/0e/91421368ae6c4f3765dd41a150f760c5f725516028a6be30e58255e3c668/ruff-0.12.12-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:59f909c0fdd8f1dcdbfed0b9569b8bf428cf144bec87d9de298dcd4723f5bee8", size = 14638365, upload-time = "2025-09-04T16:49:38.892Z" },
+    { url = "https://files.pythonhosted.org/packages/74/5d/88f3f06a142f58ecc8ecb0c2fe0b82343e2a2b04dcd098809f717cf74b6c/ruff-0.12.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9ac93d87047e765336f0c18eacad51dad0c1c33c9df7484c40f98e1d773876f5", size = 14060812, upload-time = "2025-09-04T16:49:42.732Z" },
+    { url = "https://files.pythonhosted.org/packages/13/fc/8962e7ddd2e81863d5c92400820f650b86f97ff919c59836fbc4c1a6d84c/ruff-0.12.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:01543c137fd3650d322922e8b14cc133b8ea734617c4891c5a9fccf4bfc9aa92", size = 13050208, upload-time = "2025-09-04T16:49:46.434Z" },
+    { url = "https://files.pythonhosted.org/packages/53/06/8deb52d48a9a624fd37390555d9589e719eac568c020b27e96eed671f25f/ruff-0.12.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2afc2fa864197634e549d87fb1e7b6feb01df0a80fd510d6489e1ce8c0b1cc45", size = 13311444, upload-time = "2025-09-04T16:49:49.931Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/81/de5a29af7eb8f341f8140867ffb93f82e4fde7256dadee79016ac87c2716/ruff-0.12.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:0c0945246f5ad776cb8925e36af2438e66188d2b57d9cf2eed2c382c58b371e5", size = 13279474, upload-time = "2025-09-04T16:49:53.465Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/14/d9577fdeaf791737ada1b4f5c6b59c21c3326f3f683229096cccd7674e0c/ruff-0.12.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a0fbafe8c58e37aae28b84a80ba1817f2ea552e9450156018a478bf1fa80f4e4", size = 12070204, upload-time = "2025-09-04T16:49:56.882Z" },
+    { url = "https://files.pythonhosted.org/packages/77/04/a910078284b47fad54506dc0af13839c418ff704e341c176f64e1127e461/ruff-0.12.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b9c456fb2fc8e1282affa932c9e40f5ec31ec9cbb66751a316bd131273b57c23", size = 11880347, upload-time = "2025-09-04T16:49:59.729Z" },
+    { url = "https://files.pythonhosted.org/packages/df/58/30185fcb0e89f05e7ea82e5817b47798f7fa7179863f9d9ba6fd4fe1b098/ruff-0.12.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5f12856123b0ad0147d90b3961f5c90e7427f9acd4b40050705499c98983f489", size = 12891844, upload-time = "2025-09-04T16:50:02.591Z" },
+    { url = "https://files.pythonhosted.org/packages/21/9c/28a8dacce4855e6703dcb8cdf6c1705d0b23dd01d60150786cd55aa93b16/ruff-0.12.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:26a1b5a2bf7dd2c47e3b46d077cd9c0fc3b93e6c6cc9ed750bd312ae9dc302ee", size = 13360687, upload-time = "2025-09-04T16:50:05.8Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/fa/05b6428a008e60f79546c943e54068316f32ec8ab5c4f73e4563934fbdc7/ruff-0.12.12-py3-none-win32.whl", hash = "sha256:173be2bfc142af07a01e3a759aba6f7791aa47acf3604f610b1c36db888df7b1", size = 12052870, upload-time = "2025-09-04T16:50:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/85/60/d1e335417804df452589271818749d061b22772b87efda88354cf35cdb7a/ruff-0.12.12-py3-none-win_amd64.whl", hash = "sha256:e99620bf01884e5f38611934c09dd194eb665b0109104acae3ba6102b600fd0d", size = 13178016, upload-time = "2025-09-04T16:50:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/28/7e/61c42657f6e4614a4258f1c3b0c5b93adc4d1f8575f5229d1906b483099b/ruff-0.12.12-py3-none-win_arm64.whl", hash = "sha256:2a8199cab4ce4d72d158319b63370abf60991495fb733db96cd923a34c52d093", size = 12256762, upload-time = "2025-09-04T16:50:15.737Z" },
 ]
 
 [[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]
 name = "typing-extensions"
-version = "4.14.1"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673 }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906 },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]
 name = "wat-inspector"
 version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/71/ed/463950964282fb8e40d363baeba3b2852b3dba3c1acea538e553959fa721/wat_inspector-0.4.3.tar.gz", hash = "sha256:1c47c4943eec631d7d6412f4e6a225fa29c21db30143728d6bbb6f873790ec77", size = 23023 }
+sdist = { url = "https://files.pythonhosted.org/packages/71/ed/463950964282fb8e40d363baeba3b2852b3dba3c1acea538e553959fa721/wat_inspector-0.4.3.tar.gz", hash = "sha256:1c47c4943eec631d7d6412f4e6a225fa29c21db30143728d6bbb6f873790ec77", size = 23023, upload-time = "2024-11-21T11:04:45.845Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/d0/05abf7dae933697d882ff7e410afb9b02e32640cc770cad2a63428e14f90/wat_inspector-0.4.3-py3-none-any.whl", hash = "sha256:b739b8779ccd729503caa8912cf1d1c59eba3762707f40ed6dbb92434af3bd1f", size = 15042 },
+    { url = "https://files.pythonhosted.org/packages/0e/d0/05abf7dae933697d882ff7e410afb9b02e32640cc770cad2a63428e14f90/wat_inspector-0.4.3-py3-none-any.whl", hash = "sha256:b739b8779ccd729503caa8912cf1d1c59eba3762707f40ed6dbb92434af3bd1f", size = 15042, upload-time = "2024-11-21T11:04:44.665Z" },
 ]


### PR DESCRIPTION
# Summary

The previous approach at typespecs was... haphazard at best, and had a number of bugs surrounding inconsistent handling of implicit vs explicit unions, optionals, generics, and so on. This PR takes the time to actually flesh out a proper type normalization system, resulting in much more reasonable internals for ``TypeSpec`` objects, which can now be made public. It also paves the way for a hypothetical future with an intersection type.

# Side notes

This also has some drive-by minor fixes, like adding empty docstrings to dataclasses, fixing some cosmetic issues in debugging, updating deps, etc.

# Testing

In addition to adding an end-to-end test and an integration test, this also adds a number of unit tests for normalization, which all test the ``TypeSpec.from_typehint`` classmethod under a variety of scenarios.