### PR TITLE
Fix: infer canonical origin from module annotations

### DIFF
--- a/tests_py/_gathering.e2e.test.py
+++ b/tests_py/_gathering.e2e.test.py
@@ -96,3 +96,26 @@ class TestGatheringE2E:
         assert isinstance(literal_value, Crossref)
         assert literal_value.toplevel_name == 'Singleton'
         assert literal_value.traversals == (GetattrTraversal('UNKNOWN'),)
+
+    def test_spotcheck_iso(self, testpkg_docs: Docnotes[SummaryMetadata]):
+        """A spot-check of the finnr iso module must match the
+        expected results. In particular, the mint must be correctly
+        assigned to the module, and not disowned.
+        """
+        (_, tree_root), = testpkg_docs.summaries.items()
+        iso_mod_node = tree_root.find(
+            'docnote_extract_testpkg.taevcode.finnr.iso')
+        iso_mod_summary = iso_mod_node.module_summary
+        resulting_names = {
+            child.name
+            for child in iso_mod_summary.members
+            if child.metadata.included}
+        assert resulting_names == {'mint'}
+
+        mint_summary = iso_mod_summary / GetattrTraversal('mint')
+        assert isinstance(mint_summary, VariableSummary)
+        assert mint_summary.typespec is not None
+        assert mint_summary.typespec.normtype == NormalizedConcreteType(
+            primary=Crossref(
+                module_name='finnr.currency', toplevel_name='CurrencySet'),
+            params=())


### PR DESCRIPTION
# Summary

Currently, there's very little you can do to force an instance of an imported class to be considered a variable within a module instead of a crossref with traversals; even adding module-level annotations fails to get the importing module to acquire ownership from the module where the underlying class was defined (a ``DocnoteConfig`` override on the ``canonical_module`` might partially work, but I think that still would result in a crossref and not a variable).

This PR fixes this behavior by correcting the logic within ``_get_or_infer_canonical_origin``.

# Tests

I added an e2e test to check on the finnr.iso module, which has exactly this issue.