### PR TITLE
Improve logging and increase graceful recovery around missing typevars

### DIFF
--- a/sidecars_py/docnote_extract_testpkg/src_py/docnote_extract_testpkg/_hand_rolled/has_typevars.py
+++ b/sidecars_py/docnote_extract_testpkg/src_py/docnote_extract_testpkg/_hand_rolled/has_typevars.py
@@ -10,3 +10,10 @@ def uses_module_typevar(arg: _ModuleTypeVar) -> _ModuleTypeVar: ...
 
 
 def uses_sugared_typevar[T](arg: T) -> T: ...
+
+
+class HasTypevarSuperclass[T: int](dict[T, T]):
+    """Note that we're declaring a typevar here, and then referencing
+    it within the superclasses. We need to make sure that the type var
+    here is also made available when figuring out the base classes.
+    """

--- a/src_py/docnote_extract/_extraction.py
+++ b/src_py/docnote_extract/_extraction.py
@@ -314,7 +314,7 @@ class _ExtractionFinderLoader(Loader):
         override done as part of inspection, lest we encounter circular
         imports.
         """
-        logger.info('Re-exec-ing module for tracking: %s', module_name)
+        logger.debug('Re-exec-ing module for tracking: %s', module_name)
 
         # We need to first undo any changes we might have made to
         # the type checking flag as part of re-execing the current
@@ -493,7 +493,7 @@ class _ExtractionFinderLoader(Loader):
 
     def _unstash_prehook_modules(self):
         for name, module in self.module_stash_prehook.items():
-            logger.info('Restoring prehook module %s', name)
+            logger.debug('Restoring prehook module %s', name)
             sys.modules[name] = module
 
     def _prepare_stub_or_tracking_module(
@@ -761,7 +761,7 @@ class _ExtractionFinderLoader(Loader):
             real_module = loader_state.delegated_module
 
             if loader_state.stub_strategy is _StubStrategy.TRACK:
-                logger.info(
+                logger.debug(
                     'Wrapping module w/ tracking proxy: %s',
                     loader_state.fullname)
                 module = cast(WrappedTrackingModule, module)

--- a/src_py/docnote_extract/_extraction.py
+++ b/src_py/docnote_extract/_extraction.py
@@ -932,8 +932,6 @@ def _activatate_tracking_registry(registry: TrackingRegistry):
 
 @dataclass(slots=True, kw_only=True)
 class _ExtractionLoaderState:
-    """
-    """
     fullname: str
     is_firstparty: bool
     stub_strategy: _StubStrategy

--- a/src_py/docnote_extract/_gathering.py
+++ b/src_py/docnote_extract/_gathering.py
@@ -292,8 +292,6 @@ def gather[T: SummaryMetadataProtocol](
 
 @dataclass(slots=True, frozen=True)
 class Docnotes[T: SummaryMetadataProtocol]:
-    """
-    """
     summaries: dict[str, SummaryTreeNode[T]]
 
     def is_firstparty(self, crossref: Crossref) -> bool:

--- a/src_py/docnote_extract/_gathering.py
+++ b/src_py/docnote_extract/_gathering.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import sys
 from collections.abc import Collection
 from dataclasses import dataclass
@@ -27,6 +28,8 @@ from docnote_extract.summaries import ModuleSummary
 from docnote_extract.summaries import SummaryBase
 from docnote_extract.summaries import SummaryMetadataFactoryProtocol
 from docnote_extract.summaries import SummaryMetadataProtocol
+
+logger = logging.getLogger(__name__)
 
 
 @overload
@@ -285,6 +288,8 @@ def gather[T: SummaryMetadataProtocol](
             SummaryTreeNode.from_configured_module_tree(
                 configured_tree,
                 summary_lookup)
+
+        logger.debug('Applying filtering rules for package %s', pkg_name)
         filter_module_summaries(summary_tree, configured_tree)
 
     return Docnotes(summaries)

--- a/src_py/docnote_extract/_module_tree.py
+++ b/src_py/docnote_extract/_module_tree.py
@@ -179,8 +179,6 @@ class ConfiguredModuleTreeNode(ModuleTreeNode):
 
 @dataclass(slots=True, frozen=True)
 class SummaryTreeNode[T: SummaryMetadataProtocol](ModuleTreeNode):
-    """
-    """
     _: KW_ONLY
     module_summary: ModuleSummary[T] = field(compare=False, repr=False)
     to_document: Annotated[

--- a/src_py/docnote_extract/_summarization.py
+++ b/src_py/docnote_extract/_summarization.py
@@ -143,6 +143,7 @@ def summarize_module[T: SummaryMetadataProtocol](
     normalized_objs and extracts their summaries, returning them
     combined into a single ``ModuleSummary``.
     """
+    logger.info('Creating extraction summary object for %s', module.__name__)
     module_crossref = Crossref(
         module_name=module.__name__,
         toplevel_name=None)
@@ -411,6 +412,10 @@ def _summarize_namespace_member[T: SummaryMetadataProtocol](  # noqa: PLR0913
     else:
         crossref = parent_crossref / GetattrTraversal(attr_name)
         parent_namespace[attr_name] = crossref
+
+    logger.debug(
+        'Summarizing namespace member for crossref=%s (module %s)',
+        crossref, module_name)
 
     # This seems, at first glance, to be weird. Like, how can we have a
     # module here? Except if you do ``import foo``... welp, now you have

--- a/src_py/docnote_extract/crossrefs.py
+++ b/src_py/docnote_extract/crossrefs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -15,6 +16,8 @@ from typing import TypeVar
 from typing import overload
 
 from docnote import Note
+
+logger = logging.getLogger(__name__)
 
 
 class SyntacticTraversalType(Enum):
@@ -154,8 +157,8 @@ class Crossref:
             if obj in typevars:
                 return typevars[obj]
             else:
-                raise ValueError(
-                    'Cannot create a typespec for an unknown type variable!',
+                logger.warning(
+                    'Cannot create a typespec for an unknown type variable %s',
                     obj)
 
         if (
@@ -176,13 +179,12 @@ class Crossref:
                 toplevel_name=obj.__name__,
                 traversals=())
 
+        if allow_fallback:
+            return cls.make_fallback(obj)
         else:
-            if allow_fallback:
-                return cls.make_fallback(obj)
-            else:
-                raise TypeError(
-                    'Cannot create a crossref from that object without '
-                    + 'further information!', obj)
+            raise TypeError(
+                'Cannot create a crossref from that object without '
+                + 'further information!', obj)
 
     @classmethod
     def make_fallback(

--- a/src_py/docnote_extract/crossrefs.py
+++ b/src_py/docnote_extract/crossrefs.py
@@ -25,31 +25,23 @@ class SyntacticTraversalType(Enum):
 
 @dataclass(slots=True, frozen=True)
 class SyntacticTraversal:
-    """
-    """
     type_: SyntacticTraversalType
     key: str
 
 
 @dataclass(slots=True, frozen=True)
 class GetattrTraversal:
-    """
-    """
     name: str
 
 
 @dataclass(slots=True, frozen=True)
 class CallTraversal:
-    """
-    """
     args: tuple[Any, ...]
     kwargs: dict[str, Any]
 
 
 @dataclass(slots=True, frozen=True)
 class GetitemTraversal:
-    """
-    """
     key: Any
 
 

--- a/src_py/docnote_extract/discovery.py
+++ b/src_py/docnote_extract/discovery.py
@@ -80,6 +80,8 @@ def eager_import_submodules(
     for __, submodule_name_rel, is_package in iter_modules(module.__path__):
         submodule_name_abs = f'{parent_package_name}.{submodule_name_rel}'
 
+        logger.debug(
+            'Importing module %s for submodule discovery', submodule_name_abs)
         try:
             submodule = import_module(submodule_name_abs)
         except ModuleNotFoundError:

--- a/src_py/docnote_extract/normalization.py
+++ b/src_py/docnote_extract/normalization.py
@@ -135,8 +135,6 @@ def normalize_namespace_item(
 
 @dataclass(slots=True)
 class NormalizedAnnotation:
-    """
-    """
     typespec: TypeSpec | None
     notes: tuple[Note, ...]
     config_params: DocnoteConfigParams
@@ -807,8 +805,6 @@ type NormalizedType = (
 
 @dataclass(slots=True, frozen=True)
 class LazyResolvingValue:
-    """
-    """
     _crossref: Crossref | None
     _value: Literal[Singleton.MISSING] | Any
 

--- a/src_py/docnote_extract/normalization.py
+++ b/src_py/docnote_extract/normalization.py
@@ -66,6 +66,9 @@ def normalize_namespace_item(
     """Given a single item from a namespace (ie, **not a module**), this
     creates a NormalizedObj and returns it.
     """
+    logger.debug(
+        'Normalizing namespace item w/ crossref %s (%s=%s)',
+        crossref, name_in_parent, value)
     raw_annotation = parent_annotations.get(name_in_parent, Singleton.MISSING)
     typevars = extend_typevars(
         parent_crossref=crossref,
@@ -150,6 +153,9 @@ def normalize_annotation(
     any the type hint itself, any attached notes, config params, and
     also any additional ``Annotated`` extras.
     """
+    logger.debug(
+        'Normalizing annotation %s (typevars=%s)', annotation, typevars)
+
     if annotation is Singleton.MISSING:
         return NormalizedAnnotation(
             typespec=None,
@@ -203,6 +209,7 @@ def normalize_module_dict(
                     module tree, and not just the node for the current module!
                     ''')]
         ) -> dict[str, NormalizedObj]:
+    logger.info('Normalizing module dict for %s', module.__name__)
     from_annotations: dict[str, Any] = get_type_hints(
         module, include_extras=True)
     dunder_all: set[str] = set(getattr(module, '__all__', ()))

--- a/src_py/docnote_extract/summaries.py
+++ b/src_py/docnote_extract/summaries.py
@@ -39,8 +39,6 @@ class Singleton(Enum):
 
 @dataclass(slots=True)
 class ObjClassification:
-    """
-    """
     is_reftype: bool
     has_traversals: bool | None
     is_module: bool
@@ -200,8 +198,6 @@ class ParamStyle(Enum):
 
 @dataclass(slots=True, frozen=True, kw_only=True)
 class DocText:
-    """
-    """
     value: str
     markup_lang: str | MarkupLang | None
 
@@ -353,8 +349,6 @@ type NamespaceMemberSummary[T: SummaryMetadataProtocol] = (
 
 @dataclass(slots=True, frozen=True, kw_only=True)
 class SummaryBase[T: SummaryMetadataProtocol](_SummaryBaseProtocol[T]):
-    """
-    """
     crossref: Crossref | None
     ordering_index: int | None
     child_groups: Annotated[
@@ -373,8 +367,6 @@ class SummaryBase[T: SummaryMetadataProtocol](_SummaryBaseProtocol[T]):
 
 @dataclass(slots=True, frozen=True, kw_only=True)
 class ModuleSummary[T: SummaryMetadataProtocol](SummaryBase[T]):
-    """
-    """
     name: Annotated[str, Note('The module fullname, ex ``foo.bar.baz``.')]
     dunder_all: frozenset[str] | None
     docstring: DocText | None
@@ -493,8 +485,6 @@ class VariableSummary[T: SummaryMetadataProtocol](SummaryBase[T]):
 
 @dataclass(slots=True, frozen=True, kw_only=True)
 class ClassSummary[T: SummaryMetadataProtocol](SummaryBase[T]):
-    """
-    """
     name: str
     docstring: DocText | None
     metaclass: Annotated[
@@ -544,8 +534,6 @@ class ClassSummary[T: SummaryMetadataProtocol](SummaryBase[T]):
 
 @dataclass(slots=True, frozen=True, kw_only=True)
 class CallableSummary[T: SummaryMetadataProtocol](SummaryBase[T]):
-    """
-    """
     name: str
     docstring: Annotated[
             DocText | None,
@@ -683,8 +671,6 @@ class SignatureSummary[T: SummaryMetadataProtocol](SummaryBase[T]):
 
 @dataclass(slots=True, frozen=True, kw_only=True)
 class ParamSummary[T: SummaryMetadataProtocol](SummaryBase[T]):
-    """
-    """
     name: str
     index: int
     style: ParamStyle
@@ -709,8 +695,6 @@ class ParamSummary[T: SummaryMetadataProtocol](SummaryBase[T]):
 
 @dataclass(slots=True, frozen=True, kw_only=True)
 class RetvalSummary[T: SummaryMetadataProtocol](SummaryBase[T]):
-    """
-    """
     typespec: Annotated[
         TypeSpec | None,
         Note('''Note that a value of ``None`` indicates that no type hint was

--- a/tests_py/_summarization.integr8.test.py
+++ b/tests_py/_summarization.integr8.test.py
@@ -260,8 +260,6 @@ class TestSummarization:
         sugar_summary = mod_summary / GetattrTraversal('uses_sugared_typevar')
         superclassed_summary = mod_summary / GetattrTraversal(
             'HasTypevarSuperclass')
-        dataclassed_summary = mod_summary / GetattrTraversal(
-            'SlotsDataclassWithTypevar')
 
         assert isinstance(tv_summary, TypeVarSummary)
         assert tv_summary.name == '_ModuleTypeVar'
@@ -304,10 +302,6 @@ class TestSummarization:
         assert isinstance(superclassed_summary, ClassSummary)
         # Note: dict, generic, object.
         assert len(superclassed_summary.bases) == 3
-
-        assert isinstance(dataclassed_summary, ClassSummary)
-        val_summary = dataclassed_summary / GetattrTraversal('val')
-        assert isinstance(val_summary, VariableSummary)
 
     @mocked_extraction_discovery([
         'docnote_extract_testpkg',

--- a/tests_py/_summarization.integr8.test.py
+++ b/tests_py/_summarization.integr8.test.py
@@ -258,6 +258,10 @@ class TestSummarization:
         tv_summary = mod_summary / GetattrTraversal('_ModuleTypeVar')
         modvar_summary = mod_summary / GetattrTraversal('uses_module_typevar')
         sugar_summary = mod_summary / GetattrTraversal('uses_sugared_typevar')
+        superclassed_summary = mod_summary / GetattrTraversal(
+            'HasTypevarSuperclass')
+        dataclassed_summary = mod_summary / GetattrTraversal(
+            'SlotsDataclassWithTypevar')
 
         assert isinstance(tv_summary, TypeVarSummary)
         assert tv_summary.name == '_ModuleTypeVar'
@@ -293,6 +297,17 @@ class TestSummarization:
                 SyntacticTraversal(
                     type_=SyntacticTraversalType.TYPEVAR,
                     key='T'),))
+
+        # TODO: we need to add support for actually extracting the value for
+        # the generics here; currently it is lost. See:
+        # https://github.com/python/typing/issues/777#issuecomment-761849974
+        assert isinstance(superclassed_summary, ClassSummary)
+        # Note: dict, generic, object.
+        assert len(superclassed_summary.bases) == 3
+
+        assert isinstance(dataclassed_summary, ClassSummary)
+        val_summary = dataclassed_summary / GetattrTraversal('val')
+        assert isinstance(val_summary, VariableSummary)
 
     @mocked_extraction_discovery([
         'docnote_extract_testpkg',


### PR DESCRIPTION
# Summary

This PR...
1. makes a number of QoL improvements for logging. It adds some new logging statements and tweaks log levels so that they aren't completely overwhelming when trying to debug issues with end-user code.
2. allows missing typevars to have use fallbacks instead of breaking the whole summarization

# Testing

Covered by existing tests. I didn't add a test specifically for the increased permissiveness (though maybe I should have), for the simple reason that I'm in a rush and debugging downstream issues.